### PR TITLE
New Tests added to MessageSourceController and MessageSourceDigest

### DIFF
--- a/omnichannel-server/src/feature/test/MessageSourceController.test.ts
+++ b/omnichannel-server/src/feature/test/MessageSourceController.test.ts
@@ -1,11 +1,33 @@
-import { Dependencies } from "@corecodeio/libraries/di";
-import { MessageSourceControllerInjectionKey } from "../message-source/InjectionKeys";
+import request from "supertest";
+import server from "../../server";
+import { IMessageBirdPayload } from "../message-source/interfaces/IMessageBirdPayload";
 
-const dependencies = new Dependencies();
-const messageSourceDigest = dependencies.provide(
-  MessageSourceControllerInjectionKey
-);
+describe("MessageSourceController", () => {
+  test("Should return a response with status code 200", async (done) => {
+    const currentTime = "2020-07-14T02:28:51.11316996Z";
+    const message = "Hello World Tests";
+    const from = "+123456789";
 
-describe("Testing MessageSourceController messageSource method", () => {
-  test("Should return something", () => {});
+    const body: IMessageBirdPayload = {
+      contactPhoneNumber: from,
+      currentTime,
+      payload: message,
+    };
+
+    const res = await request(server).post("/message-source").send(body);
+
+    expect(res.status).toBe(200);
+    done();
+  });
+
+  test("Should return a response with status code 500", async (done) => {
+    const body = {
+      payload: "Message",
+    };
+
+    const res = await request(server).post("/message-source").send(body);
+    const status = res.status;
+    expect(status).toBe(500);
+    done();
+  });
 });

--- a/omnichannel-server/src/feature/test/MessageSourceController.test.ts
+++ b/omnichannel-server/src/feature/test/MessageSourceController.test.ts
@@ -26,8 +26,7 @@ describe("MessageSourceController", () => {
     };
 
     const res = await request(server).post("/message-source").send(body);
-    const status = res.status;
-    expect(status).toBe(500);
+    expect(res.status).toBe(500);
     done();
   });
 });

--- a/omnichannel-server/src/feature/test/MessageSourceDigest.test.ts
+++ b/omnichannel-server/src/feature/test/MessageSourceDigest.test.ts
@@ -25,9 +25,17 @@ describe("MessageSourceDigest", () => {
       currentTime: new Date(currentTime),
       from,
     };
-    
+
     expect(messageSourceDigest.parseRequestBody(messageBirdPayload)).toEqual(
       payload
     );
+  });
+
+  test("Should return undefined", () => {
+    const unknowPayload: any = {
+      payload: "Any other payload",
+    };
+
+    expect(messageSourceDigest.parseRequestBody(unknowPayload)).toBeUndefined();
   });
 });


### PR DESCRIPTION
Se agregaron tests que hacen fallar a `MessageSourceController` y `MessageSourceDigest`.