### PR TITLE
Support for Yarn

### DIFF
--- a/native/.yarnrc
+++ b/native/.yarnrc
@@ -1,0 +1,1 @@
+"@corecodeio:registry" "https://npm.pkg.github.com/corecodeio"

--- a/omnichannel-server/.yarnrc
+++ b/omnichannel-server/.yarnrc
@@ -1,0 +1,1 @@
+"@corecodeio:registry" "https://npm.pkg.github.com/corecodeio"


### PR DESCRIPTION
Esta PR es solo colaboración general, no contiene la asignación.
No me dejaba instalar `@corecodeio/libraries` con Yarn por lo que agregue el file `.yarnrc`.

Esto soluciona los errores al intentar instalar dicha dependencia.